### PR TITLE
fix(examples): use available worker types in complete example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,6 @@
 data "alicloud_zones" "default" {
   available_resource_creation = "VSwitch"
+  available_instance_type     = data.alicloud_instance_types.cloud_essd.instance_types[0].id
 }
 
 resource "alicloud_vpc" "default" {
@@ -15,12 +16,8 @@ resource "alicloud_vswitch" "default" {
 }
 
 data "alicloud_instance_types" "cloud_essd" {
-  availability_zone    = data.alicloud_zones.default.zones[0].id
-  cpu_core_count       = 4
-  memory_size          = 16
   kubernetes_node_role = "Worker"
   system_disk_category = "cloud_essd"
-  instance_type_family = "ecs.g9i"
 }
 
 module "managed-k8s" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 locals {
-  worker_instance_type = "ecs.c7.xlarge"
+  worker_instance_type = "ecs.n4.xlarge"
 }
 
 data "alicloud_zones" "default" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -20,6 +20,7 @@ data "alicloud_instance_types" "cloud_essd" {
   memory_size          = 8
   kubernetes_node_role = "Worker"
   system_disk_category = "cloud_essd"
+  instance_type_family = "ecs.g9i"
 }
 
 module "managed-k8s" {
@@ -30,6 +31,8 @@ module "managed-k8s" {
   k8s_pod_cidr          = cidrsubnet("10.0.0.0/8", 8, 36)
   k8s_service_cidr      = cidrsubnet("172.16.0.0/16", 4, 7)
   kubernetes_version    = "1.24.6-aliyun.1"
+  cpu_core_count        = 2
+  memory_size           = 8
   worker_instance_types = [data.alicloud_instance_types.cloud_essd.instance_types[0].id]
   worker_disk_category  = "cloud_essd"
   cluster_addons = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 locals {
-  worker_instance_type = "ecs.n4.large"
+  worker_instance_type = "ecs.c7.xlarge"
 }
 
 data "alicloud_zones" "default" {
@@ -27,8 +27,8 @@ module "managed-k8s" {
   k8s_pod_cidr          = cidrsubnet("10.0.0.0/8", 8, 36)
   k8s_service_cidr      = cidrsubnet("172.16.0.0/16", 4, 7)
   kubernetes_version    = "1.24.6-aliyun.1"
-  cpu_core_count        = 2
-  memory_size           = 8
+  cpu_core_count        = 4
+  memory_size           = 16
   worker_instance_types = [local.worker_instance_type]
   worker_disk_category  = "cloud_efficiency"
   cluster_addons = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,10 @@
+locals {
+  worker_instance_type = "ecs.c7.xlarge"
+}
+
 data "alicloud_zones" "default" {
   available_resource_creation = "VSwitch"
-  available_instance_type     = data.alicloud_instance_types.cloud_essd.instance_types[0].id
+  available_instance_type     = local.worker_instance_type
 }
 
 resource "alicloud_vpc" "default" {
@@ -15,11 +19,6 @@ resource "alicloud_vswitch" "default" {
   zone_id      = data.alicloud_zones.default.zones[0].id
 }
 
-data "alicloud_instance_types" "cloud_essd" {
-  kubernetes_node_role = "Worker"
-  system_disk_category = "cloud_essd"
-}
-
 module "managed-k8s" {
   source                = "../../"
   k8s_name_prefix       = "tf-example"
@@ -30,7 +29,7 @@ module "managed-k8s" {
   kubernetes_version    = "1.24.6-aliyun.1"
   cpu_core_count        = 4
   memory_size           = 16
-  worker_instance_types = [data.alicloud_instance_types.cloud_essd.instance_types[0].id]
+  worker_instance_types = [local.worker_instance_type]
   worker_disk_category  = "cloud_essd"
   cluster_addons = [
     {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,7 @@ resource "alicloud_vswitch" "default" {
 data "alicloud_instance_types" "cloud_essd" {
   availability_zone    = data.alicloud_zones.default.zones[0].id
   cpu_core_count       = 4
-  memory_size          = 8
+  memory_size          = 16
   kubernetes_node_role = "Worker"
   system_disk_category = "cloud_essd"
   instance_type_family = "ecs.g9i"
@@ -31,8 +31,8 @@ module "managed-k8s" {
   k8s_pod_cidr          = cidrsubnet("10.0.0.0/8", 8, 36)
   k8s_service_cidr      = cidrsubnet("172.16.0.0/16", 4, 7)
   kubernetes_version    = "1.24.6-aliyun.1"
-  cpu_core_count        = 2
-  memory_size           = 8
+  cpu_core_count        = 4
+  memory_size           = 16
   worker_instance_types = [data.alicloud_instance_types.cloud_essd.instance_types[0].id]
   worker_disk_category  = "cloud_essd"
   cluster_addons = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,7 @@ module "managed-k8s" {
   cpu_core_count        = 4
   memory_size           = 16
   worker_instance_types = [local.worker_instance_type]
-  worker_disk_category  = "cloud_essd"
+  worker_disk_category  = "cloud_efficiency"
   cluster_addons = [
     {
       name   = "flannel",

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,7 @@ module "managed-k8s" {
   cpu_core_count        = 4
   memory_size           = 16
   worker_instance_types = [local.worker_instance_type]
-  worker_disk_category  = "cloud_efficiency"
+  worker_disk_category  = "cloud_essd"
   cluster_addons = [
     {
       name   = "flannel",

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 locals {
-  worker_instance_type = "ecs.c7.xlarge"
+  worker_instance_type = "ecs.g6.xlarge"
 }
 
 data "alicloud_zones" "default" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 locals {
-  worker_instance_type = "ecs.n4.xlarge"
+  worker_instance_type = "ecs.n4.large"
 }
 
 data "alicloud_zones" "default" {
@@ -27,8 +27,8 @@ module "managed-k8s" {
   k8s_pod_cidr          = cidrsubnet("10.0.0.0/8", 8, 36)
   k8s_service_cidr      = cidrsubnet("172.16.0.0/16", 4, 7)
   kubernetes_version    = "1.24.6-aliyun.1"
-  cpu_core_count        = 4
-  memory_size           = 16
+  cpu_core_count        = 2
+  memory_size           = 8
   worker_instance_types = [local.worker_instance_type]
   worker_disk_category  = "cloud_efficiency"
   cluster_addons = [

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,6 @@
 # Instance_types data source for instance_type
 data "alicloud_instance_types" "default" {
+  count = var.new_vpc && length(var.availability_zones) == 0 ? 1 : 0
   #  kubernetes_node_role = "Worker"
   cpu_core_count = var.cpu_core_count
   memory_size    = var.memory_size
@@ -7,7 +8,8 @@ data "alicloud_instance_types" "default" {
 
 # Zones data source for availability_zone
 data "alicloud_zones" "default" {
-  available_instance_type = data.alicloud_instance_types.default.ids[0]
+  count                   = var.new_vpc && length(var.availability_zones) == 0 ? 1 : 0
+  available_instance_type = data.alicloud_instance_types.default[0].ids[0]
 }
 
 # If there is not specifying vpc_id, the module will launch a new vpc
@@ -23,7 +25,7 @@ resource "alicloud_vswitch" "new" {
   count        = var.new_vpc == true ? length(var.vswitch_cidrs) : 0
   vpc_id       = concat(alicloud_vpc.new[*].id, [""])[0]
   cidr_block   = var.vswitch_cidrs[count.index]
-  zone_id      = length(var.availability_zones) > 0 ? element(var.availability_zones, count.index) : element(data.alicloud_zones.default.ids[*], count.index)
+  zone_id      = length(var.availability_zones) > 0 ? element(var.availability_zones, count.index) : element(data.alicloud_zones.default[0].ids[*], count.index)
   vswitch_name = local.new_vpc_name
   tags         = local.new_vpc_tags
 }


### PR DESCRIPTION
## Summary

Make worker instance-type discovery follow the actual network-creation path and let the complete example select a compatible type/zone pair.

## Root cause

The complete example combined zone, shape, disk, node-role, and family filters that could return no matches. Independently, the module evaluated its own discovery data sources even when it was not creating a VPC.

## Change

- query a disk- and worker-compatible type first, then select a zone supporting it
- skip internal instance-type and zone discovery unless a new VPC needs an inferred zone

## Validation

- `terraform fmt -check -recursive`
- TFLint with all configured rules
- `terraform init -upgrade`
- `terraform validate`
- `git diff --check`

Source: ODPS regression partition `20260723`.

Compatibility: no public inputs, outputs, resources, or defaults changed; data sources are skipped only on the existing external-network path. Release impact: PATCH.

The PR remains Draft while remote regression checks run.
